### PR TITLE
Remove unnecessary generics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.github.kabal163</groupId>
     <artifactId>state-machine-parent</artifactId>
     <packaging>pom</packaging>
-    <version>0.1.2-SNAPSHOT</version>
+    <version>0.2-SNAPSHOT</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>

--- a/state-machine-spring-boot-autoconfigure/pom.xml
+++ b/state-machine-spring-boot-autoconfigure/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>state-machine-parent</artifactId>
         <groupId>com.github.kabal163</groupId>
-        <version>0.1.2-SNAPSHOT</version>
+        <version>0.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>state-machine-spring-boot-autoconfigure</artifactId>

--- a/state-machine-spring-boot-autoconfigure/src/main/java/com/github/kabal163/statemachine/StateMachineAutoConfiguration.java
+++ b/state-machine-spring-boot-autoconfigure/src/main/java/com/github/kabal163/statemachine/StateMachineAutoConfiguration.java
@@ -14,9 +14,9 @@ public class StateMachineAutoConfiguration {
 
     @Bean
     @ConditionalOnBean({LifecycleConfiguration.class})
-    public <S, E> LifecycleManager<?, ?> lifecycleManager(TransitionBuilder<S, E> transitionBuilder,
-                                                          LifecycleConfiguration<S, E> lifecycleConfiguration) {
-        LifecycleManagerImpl<S, E> lifecycleManager = new LifecycleManagerImpl<>(transitionBuilder, lifecycleConfiguration);
+    public LifecycleManager lifecycleManager(TransitionBuilder transitionBuilder,
+                                                          LifecycleConfiguration lifecycleConfiguration) {
+        LifecycleManagerImpl lifecycleManager = new LifecycleManagerImpl(transitionBuilder, lifecycleConfiguration);
         lifecycleManager.init();
 
         return lifecycleManager;
@@ -24,7 +24,7 @@ public class StateMachineAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public TransitionBuilder<?, ?> transitionBuilder() {
-        return new TransitionBuilderImpl<>();
+    public TransitionBuilder transitionBuilder() {
+        return new TransitionBuilderImpl();
     }
 }

--- a/state-machine-spring-boot-samples/pom.xml
+++ b/state-machine-spring-boot-samples/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>state-machine-parent</artifactId>
         <groupId>com.github.kabal163</groupId>
-        <version>0.1.2-SNAPSHOT</version>
+        <version>0.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>state-machine-spring-boot-samples</artifactId>

--- a/state-machine-spring-boot-samples/src/main/java/com/github/kabal163/samples/entity/Order.java
+++ b/state-machine-spring-boot-samples/src/main/java/com/github/kabal163/samples/entity/Order.java
@@ -8,7 +8,7 @@ import java.time.LocalDateTime;
 import static com.github.kabal163.samples.entity.State.INIT;
 
 @Data
-public class Order implements StatefulObject<State> {
+public class Order implements StatefulObject {
 
     private String id;
 
@@ -21,4 +21,13 @@ public class Order implements StatefulObject<State> {
     private LocalDateTime deliveredTimestamp;
 
     private LocalDateTime canceledTimestamp;
+
+    @Override
+    public void setState(String state) {
+        this.state = State.valueOf(state);
+    }
+
+    public String getState() {
+        return state.name();
+    }
 }

--- a/state-machine-spring-boot-samples/src/main/java/com/github/kabal163/samples/lifecycle/OrderLifecycleConfig.java
+++ b/state-machine-spring-boot-samples/src/main/java/com/github/kabal163/samples/lifecycle/OrderLifecycleConfig.java
@@ -21,43 +21,43 @@ import static com.github.kabal163.samples.entity.State.PAID;
 
 @Configuration
 @RequiredArgsConstructor
-public class OrderLifecycleConfig implements LifecycleConfiguration<State, Event> {
+public class OrderLifecycleConfig implements LifecycleConfiguration {
 
-    private final Action<State, Event> generateIDAction;
-    private final Action<State, Event> setCreationTimestampAction;
-    private final Action<State, Event> setCanceledTimestampAction;
-    private final Action<State, Event> setPaidTimestampAction;
-    private final Action<State, Event> setDeliveredTimestampAction;
+    private final Action generateIDAction;
+    private final Action setCreationTimestampAction;
+    private final Action setCanceledTimestampAction;
+    private final Action setPaidTimestampAction;
+    private final Action setDeliveredTimestampAction;
 
-    private final Condition<State, Event> currencyCondition;
+    private final Condition currencyCondition;
 
     @Override
-    public void configureTransitions(TransitionConfigurer<State, Event> configurer) {
+    public void configureTransitions(TransitionConfigurer configurer) {
         configurer
                 .with()
-                .sourceState(INIT)
-                .targetState(NEW)
-                .event(CREATE)
+                .sourceState(INIT.name())
+                .targetState(NEW.name())
+                .event(CREATE.name())
                 .action(generateIDAction)
                 .action(setCreationTimestampAction)
 
                 .with()
-                .sourceState(NEW)
-                .targetState(PAID)
-                .event(PAY)
+                .sourceState(NEW.name())
+                .targetState(PAID.name())
+                .event(PAY.name())
                 .condition(currencyCondition)
                 .action(setPaidTimestampAction)
 
                 .with()
-                .sourceState(NEW)
-                .targetState(CANCELED)
-                .event(CANCEL)
+                .sourceState(NEW.name())
+                .targetState(CANCELED.name())
+                .event(CANCEL.name())
                 .action(setCanceledTimestampAction)
 
                 .with()
-                .sourceState(PAID)
-                .targetState(DELIVERED)
-                .event(DELIVER)
+                .sourceState(PAID.name())
+                .targetState(DELIVERED.name())
+                .event(DELIVER.name())
                 .action(setDeliveredTimestampAction);
     }
 }

--- a/state-machine-spring-boot-samples/src/main/java/com/github/kabal163/samples/lifecycle/action/GenerateIDAction.java
+++ b/state-machine-spring-boot-samples/src/main/java/com/github/kabal163/samples/lifecycle/action/GenerateIDAction.java
@@ -10,10 +10,10 @@ import com.github.kabal163.statemachine.api.StateContext;
 import java.util.UUID;
 
 @Component
-public class GenerateIDAction implements Action<State, Event> {
+public class GenerateIDAction implements Action {
 
     @Override
-    public void execute(StateContext<State, Event> context) {
+    public void execute(StateContext context) {
         Order order = context.getStatefulObject();
 
         order.setId(UUID.randomUUID().toString());

--- a/state-machine-spring-boot-samples/src/main/java/com/github/kabal163/samples/lifecycle/action/SetCanceledTimestampAction.java
+++ b/state-machine-spring-boot-samples/src/main/java/com/github/kabal163/samples/lifecycle/action/SetCanceledTimestampAction.java
@@ -10,10 +10,10 @@ import com.github.kabal163.statemachine.api.StateContext;
 import java.time.LocalDateTime;
 
 @Component
-public class SetCanceledTimestampAction implements Action<State, Event> {
+public class SetCanceledTimestampAction implements Action {
 
     @Override
-    public void execute(StateContext<State, Event> context) {
+    public void execute(StateContext context) {
         Order order = context.getStatefulObject();
 
         order.setCanceledTimestamp(LocalDateTime.now());

--- a/state-machine-spring-boot-samples/src/main/java/com/github/kabal163/samples/lifecycle/action/SetCreationTimestampAction.java
+++ b/state-machine-spring-boot-samples/src/main/java/com/github/kabal163/samples/lifecycle/action/SetCreationTimestampAction.java
@@ -10,10 +10,10 @@ import com.github.kabal163.statemachine.api.StateContext;
 import java.time.LocalDateTime;
 
 @Component
-public class SetCreationTimestampAction implements Action<State, Event> {
+public class SetCreationTimestampAction implements Action {
 
     @Override
-    public void execute(StateContext<State, Event> context) {
+    public void execute(StateContext context) {
         Order order = context.getStatefulObject();
 
         order.setCreatedTimestamp(LocalDateTime.now());

--- a/state-machine-spring-boot-samples/src/main/java/com/github/kabal163/samples/lifecycle/action/SetDeliveredTimestampAction.java
+++ b/state-machine-spring-boot-samples/src/main/java/com/github/kabal163/samples/lifecycle/action/SetDeliveredTimestampAction.java
@@ -10,10 +10,10 @@ import com.github.kabal163.statemachine.api.StateContext;
 import java.time.LocalDateTime;
 
 @Component
-public class SetDeliveredTimestampAction implements Action<State, Event> {
+public class SetDeliveredTimestampAction implements Action {
 
     @Override
-    public void execute(StateContext<State, Event> context) {
+    public void execute(StateContext context) {
         Order order = context.getStatefulObject();
 
         order.setDeliveredTimestamp(LocalDateTime.now());

--- a/state-machine-spring-boot-samples/src/main/java/com/github/kabal163/samples/lifecycle/action/SetPaidTimestampAction.java
+++ b/state-machine-spring-boot-samples/src/main/java/com/github/kabal163/samples/lifecycle/action/SetPaidTimestampAction.java
@@ -10,10 +10,10 @@ import com.github.kabal163.statemachine.api.StateContext;
 import java.time.LocalDateTime;
 
 @Component
-public class SetPaidTimestampAction implements Action<State, Event> {
+public class SetPaidTimestampAction implements Action {
 
     @Override
-    public void execute(StateContext<State, Event> context) {
+    public void execute(StateContext context) {
         Order order = context.getStatefulObject();
 
         order.setPaidTimestamp(LocalDateTime.now());

--- a/state-machine-spring-boot-samples/src/main/java/com/github/kabal163/samples/lifecycle/condition/EuroCondition.java
+++ b/state-machine-spring-boot-samples/src/main/java/com/github/kabal163/samples/lifecycle/condition/EuroCondition.java
@@ -13,12 +13,12 @@ import static com.github.kabal163.samples.lifecycle.Constants.CURRENCY;
 @Component
 @Profile("eur")
 @Qualifier("currencyCondition")
-public class EuroCondition implements Condition<State, Event> {
+public class EuroCondition implements Condition {
 
     private static final String EURO_CURRENCY = "EUR";
 
     @Override
-    public boolean evaluate(StateContext<State, Event> context) {
+    public boolean evaluate(StateContext context) {
         String currency = context.getVariable(CURRENCY, String.class);
 
         return EURO_CURRENCY.equals(currency);

--- a/state-machine-spring-boot-samples/src/main/java/com/github/kabal163/samples/lifecycle/condition/RurCondition.java
+++ b/state-machine-spring-boot-samples/src/main/java/com/github/kabal163/samples/lifecycle/condition/RurCondition.java
@@ -13,12 +13,12 @@ import static com.github.kabal163.samples.lifecycle.Constants.CURRENCY;
 @Component
 @Profile("rus")
 @Qualifier("currencyCondition")
-public class RurCondition implements Condition<State, Event> {
+public class RurCondition implements Condition {
 
     private static final String RUR_CURRENCY = "RUR";
 
     @Override
-    public boolean evaluate(StateContext<State, Event> context) {
+    public boolean evaluate(StateContext context) {
         String currency = context.getVariable(CURRENCY, String.class);
 
         return RUR_CURRENCY.equals(currency);

--- a/state-machine-spring-boot-samples/src/main/java/com/github/kabal163/samples/service/OrderServiceImpl.java
+++ b/state-machine-spring-boot-samples/src/main/java/com/github/kabal163/samples/service/OrderServiceImpl.java
@@ -22,12 +22,12 @@ import static com.github.kabal163.samples.entity.Event.PAY;
 @RequiredArgsConstructor
 public class OrderServiceImpl implements OrderService {
 
-    private final LifecycleManager<State, Event> lifecycleManager;
+    private final LifecycleManager lifecycleManager;
     private final OrderRepository repository;
 
     @Override
     public Order create() {
-        TransitionResult<State, Event> result = lifecycleManager.execute(new Order(), CREATE);
+        TransitionResult result = lifecycleManager.execute(new Order(), CREATE.name());
         Order order = result
                 .getStateContext()
                 .getStatefulObject();
@@ -42,7 +42,7 @@ public class OrderServiceImpl implements OrderService {
         contextVariables.put(Constants.CURRENCY, currency);
         contextVariables.put(Constants.SUM, amount);
 
-        lifecycleManager.execute(order, PAY, contextVariables);
+        lifecycleManager.execute(order, PAY.name(), contextVariables);
 
         return repository.save(order);
     }
@@ -50,7 +50,7 @@ public class OrderServiceImpl implements OrderService {
     @Override
     public Order cancel(String id) {
         Order order = repository.find(id).orElseThrow();
-        lifecycleManager.execute(order, CANCEL);
+        lifecycleManager.execute(order, CANCEL.name());
 
         return repository.save(order);
     }
@@ -58,7 +58,7 @@ public class OrderServiceImpl implements OrderService {
     @Override
     public Order deliver(String id) {
         Order order = repository.find(id).orElseThrow();
-        lifecycleManager.execute(order, DELIVER);
+        lifecycleManager.execute(order, DELIVER.name());
 
         return repository.save(order);
     }

--- a/state-machine-spring-boot-samples/src/test/java/com/github/kabal163/samples/service/OrderServiceImplTest.java
+++ b/state-machine-spring-boot-samples/src/test/java/com/github/kabal163/samples/service/OrderServiceImplTest.java
@@ -30,7 +30,7 @@ class OrderServiceImplTest {
         assertNotNull(order);
         assertNotNull(order.getId());
         assertNotNull(order.getCreatedTimestamp());
-        assertEquals(NEW, order.getState());
+        assertEquals(NEW.name(), order.getState());
     }
 
     @Test
@@ -38,7 +38,7 @@ class OrderServiceImplTest {
         Order order = orderService.create();
         orderService.pay(order.getId(), "RUR", 200);
 
-        assertEquals(PAID, order.getState());
+        assertEquals(PAID.name(), order.getState());
         assertNotNull(order.getPaidTimestamp());
     }
 
@@ -47,7 +47,7 @@ class OrderServiceImplTest {
         Order order = orderService.create();
         orderService.pay(order.getId(), "EUR", 200);
 
-        assertEquals(NEW, order.getState());
+        assertEquals(NEW.name(), order.getState());
         assertNull(order.getPaidTimestamp());
     }
 
@@ -56,7 +56,7 @@ class OrderServiceImplTest {
         Order order = orderService.create();
         orderService.cancel(order.getId());
 
-        assertEquals(CANCELED, order.getState());
+        assertEquals(CANCELED.name(), order.getState());
         assertNotNull(order.getCreatedTimestamp());
     }
 
@@ -66,7 +66,7 @@ class OrderServiceImplTest {
         orderService.pay(order.getId(), "RUR", 200);
         orderService.deliver(order.getId());
 
-        assertEquals(DELIVERED, order.getState());
+        assertEquals(DELIVERED.name(), order.getState());
         assertNotNull(order.getDeliveredTimestamp());
     }
 

--- a/state-machine-spring-boot-starter/pom.xml
+++ b/state-machine-spring-boot-starter/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>state-machine-parent</artifactId>
         <groupId>com.github.kabal163</groupId>
-        <version>0.1.2-SNAPSHOT</version>
+        <version>0.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>state-machine-spring-boot-starter</artifactId>

--- a/state-machine/pom.xml
+++ b/state-machine/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>state-machine-parent</artifactId>
         <groupId>com.github.kabal163</groupId>
-        <version>0.1.2-SNAPSHOT</version>
+        <version>0.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>state-machine</artifactId>

--- a/state-machine/src/main/java/com/github/kabal163/statemachine/LifecycleManagerImpl.java
+++ b/state-machine/src/main/java/com/github/kabal163/statemachine/LifecycleManagerImpl.java
@@ -18,12 +18,12 @@ import java.util.stream.Collectors;
 
 @Slf4j
 @RequiredArgsConstructor
-public class LifecycleManagerImpl<S, E> implements LifecycleManager<S, E> {
+public class LifecycleManagerImpl implements LifecycleManager {
 
-    private final TransitionBuilder<S, E> transitionBuilder;
-    private final LifecycleConfiguration<S, E> lifecycleConfiguration;
+    private final TransitionBuilder transitionBuilder;
+    private final LifecycleConfiguration lifecycleConfiguration;
 
-    private Set<Transition<S, E>> transitions;
+    private Set<Transition> transitions;
 
     public void init() {
         lifecycleConfiguration.configureTransitions(transitionBuilder);
@@ -31,14 +31,14 @@ public class LifecycleManagerImpl<S, E> implements LifecycleManager<S, E> {
     }
 
     @Override
-    public TransitionResult<S, E> execute(StatefulObject<S> statefulObject, E event) {
+    public TransitionResult execute(StatefulObject statefulObject, String event) {
         return execute(statefulObject, event, new HashMap<>());
     }
 
     @Override
-    public TransitionResult<S, E> execute(StatefulObject<S> statefulObject, E event, Map<String, Object> variables) {
-        Transition<S, E> transition = getMatchingTransition(statefulObject, event);
-        StateContext<S, E> context = new StateContext<>(statefulObject, event, variables);
+    public TransitionResult execute(StatefulObject statefulObject, String event, Map<String, Object> variables) {
+        Transition transition = getMatchingTransition(statefulObject, event);
+        StateContext context = new StateContext(statefulObject, event, variables);
         boolean success = false;
         Exception exception = null;
 
@@ -58,7 +58,7 @@ public class LifecycleManagerImpl<S, E> implements LifecycleManager<S, E> {
             statefulObject.setState(transition.getTargetState());
         }
 
-        return new TransitionResult<>(
+        return new TransitionResult(
                 success,
                 context,
                 transition.getSourceState(),
@@ -66,10 +66,10 @@ public class LifecycleManagerImpl<S, E> implements LifecycleManager<S, E> {
                 exception);
     }
 
-    private Transition<S, E> getMatchingTransition(StatefulObject<S> statefulObject, E event) {
-        S sourceState = statefulObject.getState();
+    private Transition getMatchingTransition(StatefulObject statefulObject, String event) {
+        String sourceState = statefulObject.getState();
 
-        Set<Transition<S, E>> matchTransitions = transitions.stream()
+        Set<Transition> matchTransitions = transitions.stream()
                 .filter(t -> Objects.equals(t.getSourceState(), sourceState))
                 .filter(t -> Objects.equals(t.getEvent(), event))
                 .collect(Collectors.toSet());

--- a/state-machine/src/main/java/com/github/kabal163/statemachine/Transition.java
+++ b/state-machine/src/main/java/com/github/kabal163/statemachine/Transition.java
@@ -13,16 +13,17 @@ import java.util.List;
 import java.util.Set;
 
 @Data
-class Transition<S, E> {
+class Transition {
 
-    private S sourceState;
-    private S targetState;
-    private E event;
+    //todo make all field final
+    private String sourceState;
+    private String targetState;
+    private String event;
 
-    private Set<Condition<S, E>> conditions = new HashSet<>();
-    private List<Action<S, E>> actions = new LinkedList<>();
+    private Set<Condition> conditions = new HashSet<>();
+    private List<Action> actions = new LinkedList<>();
 
-    public boolean transit(StateContext<S, E> context) {
+    public boolean transit(StateContext context) {
         if (!conditions.stream().allMatch(condition -> condition.evaluate(context))) {
             return false;
         }
@@ -31,19 +32,19 @@ class Transition<S, E> {
         return true;
     }
 
-    public void addAction(Action<S, E> action) {
+    public void addAction(Action action) {
         actions.add(action);
     }
 
-    public void addCondition(Condition<S, E> condition) {
+    public void addCondition(Condition condition) {
         conditions.add(condition);
     }
 
-    public Collection<Condition<S, E>> getConditions() {
+    public Collection<Condition> getConditions() {
         return new HashSet<>(conditions);
     }
 
-    public Collection<Action<S, E>> getActions() {
+    public Collection<Action> getActions() {
         return new ArrayList<>(actions);
     }
 }

--- a/state-machine/src/main/java/com/github/kabal163/statemachine/TransitionBuilder.java
+++ b/state-machine/src/main/java/com/github/kabal163/statemachine/TransitionBuilder.java
@@ -2,7 +2,7 @@ package com.github.kabal163.statemachine;
 
 import java.util.Set;
 
-interface TransitionBuilder<S, E> extends TransitionConfigurer<S, E> {
+interface TransitionBuilder extends TransitionConfigurer {
 
-    Set<Transition<S, E>> buildTransitions();
+    Set<Transition> buildTransitions();
 }

--- a/state-machine/src/main/java/com/github/kabal163/statemachine/TransitionBuilderImpl.java
+++ b/state-machine/src/main/java/com/github/kabal163/statemachine/TransitionBuilderImpl.java
@@ -12,21 +12,21 @@ import static org.apache.commons.lang3.ObjectUtils.allNotNull;
 
 @Slf4j
 @RequiredArgsConstructor
-public class TransitionBuilderImpl<S, E> implements TransitionBuilder<S, E> {
+public class TransitionBuilderImpl implements TransitionBuilder {
 
-    private final Set<Transition<S, E>> configuredTransitions = new HashSet<>();
-    private Transition<S, E> configuredTransition;
+    private final Set<Transition> configuredTransitions = new HashSet<>();
+    private Transition configuredTransition;
 
     @Override
-    public TransitionConfigurer<S, E> with() {
-        configuredTransition = new Transition<>();
+    public TransitionConfigurer with() {
+        configuredTransition = new Transition();
         configuredTransitions.add(configuredTransition);
 
         return this;
     }
 
     @Override
-    public TransitionConfigurer<S, E> sourceState(S state) {
+    public TransitionConfigurer sourceState(String state) {
         assertConfiguredTransitionIsNotNull();
         configuredTransition.setSourceState(state);
 
@@ -34,7 +34,7 @@ public class TransitionBuilderImpl<S, E> implements TransitionBuilder<S, E> {
     }
 
     @Override
-    public TransitionConfigurer<S, E> targetState(S state) {
+    public TransitionConfigurer targetState(String state) {
         assertConfiguredTransitionIsNotNull();
         configuredTransition.setTargetState(state);
 
@@ -42,7 +42,7 @@ public class TransitionBuilderImpl<S, E> implements TransitionBuilder<S, E> {
     }
 
     @Override
-    public TransitionConfigurer<S, E> event(E event) {
+    public TransitionConfigurer event(String event) {
         assertConfiguredTransitionIsNotNull();
         configuredTransition.setEvent(event);
 
@@ -50,7 +50,7 @@ public class TransitionBuilderImpl<S, E> implements TransitionBuilder<S, E> {
     }
 
     @Override
-    public TransitionConfigurer<S, E> condition(Condition<S, E> condition) {
+    public TransitionConfigurer condition(Condition condition) {
         assertConfiguredTransitionIsNotNull();
         if (condition == null) {
             throw new IllegalArgumentException("Condition must not be null!");
@@ -61,7 +61,7 @@ public class TransitionBuilderImpl<S, E> implements TransitionBuilder<S, E> {
     }
 
     @Override
-    public TransitionConfigurer<S, E> action(Action<S, E> action) {
+    public TransitionConfigurer action(Action action) {
         assertConfiguredTransitionIsNotNull();
         if (action == null) {
             throw new IllegalArgumentException("Action must not be null!");
@@ -72,8 +72,8 @@ public class TransitionBuilderImpl<S, E> implements TransitionBuilder<S, E> {
     }
 
     @Override
-    public Set<Transition<S, E>> buildTransitions() {
-        for (Transition<S, E> transition : configuredTransitions) {
+    public Set<Transition> buildTransitions() {
+        for (Transition transition : configuredTransitions) {
             if (!allNotNull(
                     transition.getSourceState(),
                     transition.getTargetState(),

--- a/state-machine/src/main/java/com/github/kabal163/statemachine/TransitionConfigurer.java
+++ b/state-machine/src/main/java/com/github/kabal163/statemachine/TransitionConfigurer.java
@@ -7,15 +7,12 @@ import com.github.kabal163.statemachine.api.Condition;
  * Convenient component which helps to configure the lifecycle effortless.
  * The important thing is the {@code with()} method must be called each time
  * before you started to describe a transition.
- * E.x. {@code configurer.with().sourceState(State.NEW).targetState(State.APPROVED)...}
+ * E.x. {@code configurer.with().sourceState("NEW").targetState("APPROVED")...}
  * For more details see: https://github.com/Kabal163/akuna-state-machine/tree/master/state-machine-spring-boot-samples
  * Any configured transition must contain at least {@code sourceState}, {@code targetState} and {@code event}
  * The other attributes are optional
- *
- * @param <S> a state of a stateful object
- * @param <E> an event which triggers a transition
  */
-public interface TransitionConfigurer<S, E> {
+public interface TransitionConfigurer {
 
     /**
      * Used to define the new one described transition.
@@ -23,45 +20,45 @@ public interface TransitionConfigurer<S, E> {
      *
      * @return the configurer instance
      */
-    TransitionConfigurer<S, E> with();
+    TransitionConfigurer with();
 
     /**
      * Defines a state which must correspond to the stateful object's state
      * at the moment of start a transition. This is the mandatory attribute
      * which must be specified for each transition. The {@param state} state
-     * must not be {@code null} otherwise {@link IllegalStateException} will be
+     * must be neither {@code null} nor empty string otherwise {@link IllegalStateException} will be
      * thrown while building a transition.
      *
      * @param state state which must correspond to the stateful object's state
      *              at the moment of start a transition
      * @return the configurer instance
      */
-    TransitionConfigurer<S, E> sourceState(S state);
+    TransitionConfigurer sourceState(String state);
 
     /**
      * Defines a desired state which should be on the stateful object
      * after transition finish. This is the mandatory attribute
      * which must be specified for each transition. The {@param state} state
-     * must not be {@code null} otherwise {@link IllegalStateException} will be
+     * must be neither {@code null} nor empty string otherwise {@link IllegalStateException} will be
      * thrown while building a transition.
      *
      * @param state the desired state which should be on the stateful object
      *              after transition finish
      * @return the configurer instance
      */
-    TransitionConfigurer<S, E> targetState(S state);
+    TransitionConfigurer targetState(String state);
 
     /**
      * Defines a trigger which along with the source state defines the transition
      * which must be executed. This is the mandatory attribute which must be
      * specified for each transition. The {@param event} state
-     * must not be {@code null} otherwise {@link IllegalStateException} will be
+     * must be neither {@code null} nor empty string otherwise {@link IllegalStateException} will be
      * thrown while building a transition.
      *
      * @param event a trigger which defines a cause of transition execution
      * @return the configurer instance
      */
-    TransitionConfigurer<S, E> event(E event);
+    TransitionConfigurer event(String event);
 
     /**
      * Defines a guard which prevents transition execution. Each transition
@@ -73,7 +70,7 @@ public interface TransitionConfigurer<S, E> {
      * @param condition a guard which prevents transition execution
      * @return the configurer instance
      */
-    TransitionConfigurer<S, E> condition(Condition<S, E> condition);
+    TransitionConfigurer condition(Condition condition);
 
     /**
      * Defines a piece of work which must be performed in order to transit
@@ -85,5 +82,5 @@ public interface TransitionConfigurer<S, E> {
      *               the stateful object to the target state
      * @return the configurer instance
      */
-    TransitionConfigurer<S, E> action(Action<S, E> action);
+    TransitionConfigurer action(Action action);
 }

--- a/state-machine/src/main/java/com/github/kabal163/statemachine/api/Action.java
+++ b/state-machine/src/main/java/com/github/kabal163/statemachine/api/Action.java
@@ -8,11 +8,8 @@ package com.github.kabal163.statemachine.api;
  * Implement this interface and put there any logic which is needed
  * during a transition. Use it in your {@link LifecycleConfiguration}
  * lifecycle configuration.
- *
- * @param <S> a state of a stateful object
- * @param <E> an event which triggers a transition
  */
-public interface Action<S, E> {
+public interface Action {
 
     /**
      * Performs a unit of work to execute transition
@@ -21,5 +18,5 @@ public interface Action<S, E> {
      *
      * @param context contains information about the current transition
      */
-    void execute(StateContext<S, E> context);
+    void execute(StateContext context);
 }

--- a/state-machine/src/main/java/com/github/kabal163/statemachine/api/Condition.java
+++ b/state-machine/src/main/java/com/github/kabal163/statemachine/api/Condition.java
@@ -7,11 +7,8 @@ package com.github.kabal163.statemachine.api;
  * as impossible and should not be executed.
  * Implement this interface to define if the current transition is allowed
  * to be executed. Use it in your {@link LifecycleConfiguration} lifecycle configuration.
- *
- * @param <S> a state of a stateful object
- * @param <E> an event which triggers a transition
  */
-public interface Condition<S, E> {
+public interface Condition {
 
     /**
      * Defines if the current transition is allowed to be executed.
@@ -21,5 +18,5 @@ public interface Condition<S, E> {
      * @param context contains information about the current transition
      * @return true if all conditions are met requirements. Otherwise false
      */
-    boolean evaluate(StateContext<S, E> context);
+    boolean evaluate(StateContext context);
 }

--- a/state-machine/src/main/java/com/github/kabal163/statemachine/api/LifecycleConfiguration.java
+++ b/state-machine/src/main/java/com/github/kabal163/statemachine/api/LifecycleConfiguration.java
@@ -7,11 +7,8 @@ import com.github.kabal163.statemachine.TransitionConfigurer;
  * a lifecycle of a stateful object. Now there are no another
  * way to configure it. Use your {@link Action} actions and
  * {@link Condition} conditions to describe the lifecycle.
- *
- * @param <S> a state of a stateful object
- * @param <E> an event which triggers a transition
  */
-public interface LifecycleConfiguration<S, E> {
+public interface LifecycleConfiguration {
 
     /**
      * Should describe the lifecycle of a stateful object.
@@ -19,5 +16,5 @@ public interface LifecycleConfiguration<S, E> {
      * @param configurer is a convenient component which helps you
      *                   to configure the lifecycle
      */
-    void configureTransitions(TransitionConfigurer<S, E> configurer);
+    void configureTransitions(TransitionConfigurer configurer);
 }

--- a/state-machine/src/main/java/com/github/kabal163/statemachine/api/LifecycleManager.java
+++ b/state-machine/src/main/java/com/github/kabal163/statemachine/api/LifecycleManager.java
@@ -11,11 +11,8 @@ import java.util.Map;
  * uses internally {@link LifecycleConfiguration} lifecycle configuration
  * which must be configured by a user. If any exception occurs during a transition
  * will be placed into the {@link TransitionResult} transition result.
- *
- * @param <S> a state of a stateful object
- * @param <E> an event which triggers a transition
  */
-public interface LifecycleManager<S, E> {
+public interface LifecycleManager {
 
     /**
      * Executes a transition of the stateful object according the event.
@@ -29,7 +26,7 @@ public interface LifecycleManager<S, E> {
      * stateful object's source state and event
      * @throws AmbiguousTransitionException if there are more then one matching transitions
      */
-    TransitionResult<S, E> execute(StatefulObject<S> statefulObject, E event);
+    TransitionResult execute(StatefulObject statefulObject, String event);
 
     /**
      * Executes a transition of the stateful object according the event.
@@ -46,5 +43,5 @@ public interface LifecycleManager<S, E> {
      * stateful object's source state and event
      * @throws AmbiguousTransitionException if there are more then one matching transitions
      */
-    TransitionResult<S, E> execute(StatefulObject<S> statefulObject, E event, Map<String, Object> variables);
+    TransitionResult execute(StatefulObject statefulObject, String event, Map<String, Object> variables);
 }

--- a/state-machine/src/main/java/com/github/kabal163/statemachine/api/StateContext.java
+++ b/state-machine/src/main/java/com/github/kabal163/statemachine/api/StateContext.java
@@ -7,15 +7,12 @@ import java.util.Map;
 /**
  * Contains information about the transition. It helps to share
  * information between actions and conditions.
- *
- * @param <S> a state of a stateful object
- * @param <E> an event which triggers a transition
  */
 @RequiredArgsConstructor
-public class StateContext<S, E> {
+public class StateContext {
 
-    private final StatefulObject<S> statefulObject;
-    private final E event;
+    private final StatefulObject statefulObject;
+    private final String event;
     private final Map<String, Object> variables;
 
     public void putVariable(String key, Object value) {
@@ -44,7 +41,7 @@ public class StateContext<S, E> {
         return (T) statefulObject;
     }
 
-    public E getEvent() {
+    public String getEvent() {
         return event;
     }
 }

--- a/state-machine/src/main/java/com/github/kabal163/statemachine/api/StatefulObject.java
+++ b/state-machine/src/main/java/com/github/kabal163/statemachine/api/StatefulObject.java
@@ -4,10 +4,8 @@ package com.github.kabal163.statemachine.api;
  * Any entity which is needed to be managed by {@link LifecycleManager}
  * lifecycle manager must implement this interface. This provides
  * the minimum of methods which are necessary for executing a transition.
- *
- * @param <S> a state of the stateful object
  */
-public interface StatefulObject<S> {
+public interface StatefulObject {
 
     /**
      * Returns the stateful object's id
@@ -22,7 +20,7 @@ public interface StatefulObject<S> {
      *
      * @return the actual state of the stateful object
      */
-    S getState();
+    String getState();
 
     /**
      * Sets the state to the stateful object. Should not be
@@ -30,5 +28,5 @@ public interface StatefulObject<S> {
      *
      * @param state new state to the stateful object
      */
-    void setState(S state);
+    void setState(String state);
 }

--- a/state-machine/src/main/java/com/github/kabal163/statemachine/api/TransitionResult.java
+++ b/state-machine/src/main/java/com/github/kabal163/statemachine/api/TransitionResult.java
@@ -7,13 +7,10 @@ import lombok.RequiredArgsConstructor;
  * Contains the main information about executed transition.
  * If there were no exceptions then {@code exception} field
  * will be {@code null}.
- *
- * @param <S> a state of a stateful object
- * @param <E> an event which triggers a transition
  */
 @Getter
 @RequiredArgsConstructor
-public class TransitionResult<S, E> {
+public class TransitionResult {
 
     /**
      * Whether the transition was successful or not
@@ -23,13 +20,13 @@ public class TransitionResult<S, E> {
     /**
      * The shared context of the transition
      */
-    private final StateContext<S, E> stateContext;
+    private final StateContext stateContext;
 
     /**
      * The state which stateful object has at the moment
      * of start the transition
      */
-    private final S sourceState;
+    private final String sourceState;
 
     /**
      * The state which stateful object should has at the moment
@@ -37,7 +34,7 @@ public class TransitionResult<S, E> {
      * doesn't match the actual state of the stateful object after
      * transition execution due to exceptions.
      */
-    private final S targetState;
+    private final String targetState;
 
     /**
      * Any exception which happened during actions or conditions execution

--- a/state-machine/src/test/java/com/github/kabal163/statemachine/LifecycleManagerImplTest.java
+++ b/state-machine/src/test/java/com/github/kabal163/statemachine/LifecycleManagerImplTest.java
@@ -6,8 +6,6 @@ import com.github.kabal163.statemachine.api.StatefulObject;
 import com.github.kabal163.statemachine.api.TransitionResult;
 import com.github.kabal163.statemachine.exception.AmbiguousTransitionException;
 import com.github.kabal163.statemachine.exception.TransitionNotFoundException;
-import com.github.kabal163.statemachine.testimpl.Event;
-import com.github.kabal163.statemachine.testimpl.State;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -20,11 +18,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import static com.github.kabal163.statemachine.testimpl.Event.APPROVE;
-import static com.github.kabal163.statemachine.testimpl.Event.CANCEL;
-import static com.github.kabal163.statemachine.testimpl.State.APPROVED;
-import static com.github.kabal163.statemachine.testimpl.State.CANCELED;
-import static com.github.kabal163.statemachine.testimpl.State.NEW;
 import static java.util.Collections.singletonMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -35,14 +28,13 @@ import static org.mockito.ArgumentMatchers.any;
 
 class LifecycleManagerImplTest {
 
-    LifecycleManagerImpl<State, Event> lifecycleManager;
+    LifecycleManagerImpl lifecycleManager;
 
-    LifecycleConfiguration<State, Event> lifecycleConfiguration;
-    TransitionBuilder<State, Event> transitionBuilder;
-    Transition<State, Event> approveTransition;
-    Transition<State, Event> cancelTransition;
+    LifecycleConfiguration lifecycleConfiguration;
+    TransitionBuilder transitionBuilder;
+    Transition approveTransition;
+    Transition cancelTransition;
 
-    @SuppressWarnings("unchecked")
     LifecycleManagerImplTest() {
         lifecycleConfiguration = Mockito.mock(LifecycleConfiguration.class);
         transitionBuilder = Mockito.mock(TransitionBuilder.class);
@@ -52,243 +44,228 @@ class LifecycleManagerImplTest {
 
     @BeforeEach
     void setUp() {
-        Mockito.when(approveTransition.getSourceState()).thenReturn(NEW);
-        Mockito.when(approveTransition.getTargetState()).thenReturn(APPROVED);
-        Mockito.when(approveTransition.getEvent()).thenReturn(APPROVE);
+        Mockito.when(approveTransition.getSourceState()).thenReturn("NEW");
+        Mockito.when(approveTransition.getTargetState()).thenReturn("APPROVED");
+        Mockito.when(approveTransition.getEvent()).thenReturn("APPROVE");
         Mockito.when(approveTransition.transit(any())).thenReturn(true);
 
-        Mockito.when(cancelTransition.getSourceState()).thenReturn(NEW);
-        Mockito.when(cancelTransition.getTargetState()).thenReturn(CANCELED);
-        Mockito.when(cancelTransition.getEvent()).thenReturn(CANCEL);
+        Mockito.when(cancelTransition.getSourceState()).thenReturn("NEW");
+        Mockito.when(cancelTransition.getTargetState()).thenReturn("CANCELED");
+        Mockito.when(cancelTransition.getEvent()).thenReturn("CANCEL");
         Mockito.when(cancelTransition.transit(any())).thenReturn(true);
 
         Mockito.when(transitionBuilder.buildTransitions()).thenReturn(Set.of(approveTransition, cancelTransition));
 
-        lifecycleManager = new LifecycleManagerImpl<>(transitionBuilder, lifecycleConfiguration);
+        lifecycleManager = new LifecycleManagerImpl(transitionBuilder, lifecycleConfiguration);
         lifecycleManager.init();
     }
 
     @ParameterizedTest
     @MethodSource("getValidStatefulObjects")
-    void transitionMustBeFound(StatefulObject<State> statefulObject, Event event) {
-        TransitionResult<State, Event> result = lifecycleManager.execute(statefulObject, event);
+    void transitionMustBeFound(StatefulObject statefulObject, String event) {
+        TransitionResult result = lifecycleManager.execute(statefulObject, event);
         assertTrue(result.isSuccess());
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     void approvedTransitionMustBeUsed() {
-        StatefulObject<State> statefulObject = Mockito.mock(StatefulObject.class);
-        Mockito.when(statefulObject.getState()).thenReturn(NEW);
+        StatefulObject statefulObject = Mockito.mock(StatefulObject.class);
+        Mockito.when(statefulObject.getState()).thenReturn("NEW");
         Mockito.doNothing().when(statefulObject).setState(any());
 
-        lifecycleManager.execute(statefulObject, APPROVE);
+        lifecycleManager.execute(statefulObject, "APPROVE");
 
         Mockito.verify(approveTransition, Mockito.times(1)).transit(any());
         Mockito.verify(cancelTransition, Mockito.times(0)).transit(any());
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     void cancelTransitionMustBeUsed() {
-        StatefulObject<State> statefulObject = Mockito.mock(StatefulObject.class);
-        Mockito.when(statefulObject.getState()).thenReturn(NEW);
+        StatefulObject statefulObject = Mockito.mock(StatefulObject.class);
+        Mockito.when(statefulObject.getState()).thenReturn("NEW");
         Mockito.doNothing().when(statefulObject).setState(any());
 
-        lifecycleManager.execute(statefulObject, CANCEL);
+        lifecycleManager.execute(statefulObject, "CANCEL");
 
         Mockito.verify(approveTransition, Mockito.times(0)).transit(any());
         Mockito.verify(cancelTransition, Mockito.times(1)).transit(any());
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     void contextMustContainStatefulObject() {
-        StatefulObject<State> statefulObject = Mockito.mock(StatefulObject.class);
-        Mockito.when(statefulObject.getState()).thenReturn(NEW);
+        StatefulObject statefulObject = Mockito.mock(StatefulObject.class);
+        Mockito.when(statefulObject.getState()).thenReturn("NEW");
         Mockito.doNothing().when(statefulObject).setState(any());
 
-        ArgumentCaptor<StateContext<State, Event>> contextCaptor = ArgumentCaptor.forClass(StateContext.class);
+        ArgumentCaptor<StateContext> contextCaptor = ArgumentCaptor.forClass(StateContext.class);
         Mockito.when(approveTransition.transit(contextCaptor.capture())).thenReturn(true);
 
-        lifecycleManager.execute(statefulObject, APPROVE);
-        StateContext<State, Event> context = contextCaptor.getValue();
+        lifecycleManager.execute(statefulObject, "APPROVE");
+        StateContext context = contextCaptor.getValue();
 
         assertEquals(statefulObject, context.getStatefulObject());
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     void contextMustContainEvent() {
-        StatefulObject<State> statefulObject = Mockito.mock(StatefulObject.class);
-        Mockito.when(statefulObject.getState()).thenReturn(NEW);
+        StatefulObject statefulObject = Mockito.mock(StatefulObject.class);
+        Mockito.when(statefulObject.getState()).thenReturn("NEW");
         Mockito.doNothing().when(statefulObject).setState(any());
 
-        ArgumentCaptor<StateContext<State, Event>> contextCaptor = ArgumentCaptor.forClass(StateContext.class);
+        ArgumentCaptor<StateContext> contextCaptor = ArgumentCaptor.forClass(StateContext.class);
         Mockito.when(approveTransition.transit(contextCaptor.capture())).thenReturn(true);
 
-        lifecycleManager.execute(statefulObject, APPROVE);
-        StateContext<State, Event> context = contextCaptor.getValue();
+        lifecycleManager.execute(statefulObject, "APPROVE");
+        StateContext context = contextCaptor.getValue();
 
-        assertEquals(APPROVE, context.getEvent());
+        assertEquals("APPROVE", context.getEvent());
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     void contextMustContainVariables() {
-        StatefulObject<State> statefulObject = Mockito.mock(StatefulObject.class);
-        Mockito.when(statefulObject.getState()).thenReturn(NEW);
+        StatefulObject statefulObject = Mockito.mock(StatefulObject.class);
+        Mockito.when(statefulObject.getState()).thenReturn("NEW");
         Mockito.doNothing().when(statefulObject).setState(any());
 
-        ArgumentCaptor<StateContext<State, Event>> contextCaptor = ArgumentCaptor.forClass(StateContext.class);
+        ArgumentCaptor<StateContext> contextCaptor = ArgumentCaptor.forClass(StateContext.class);
         Mockito.when(approveTransition.transit(contextCaptor.capture())).thenReturn(true);
         Map<String, Object> variables = singletonMap("testKey", "testValue");
 
-        lifecycleManager.execute(statefulObject, APPROVE, variables);
-        StateContext<State, Event> context = contextCaptor.getValue();
+        lifecycleManager.execute(statefulObject, "APPROVE", variables);
+        StateContext context = contextCaptor.getValue();
 
         assertEquals("testValue", context.getVariable("testKey", String.class));
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     void contextVariablesMustBeAppendable() {
-        StatefulObject<State> statefulObject = Mockito.mock(StatefulObject.class);
-        Mockito.when(statefulObject.getState()).thenReturn(NEW);
+        StatefulObject statefulObject = Mockito.mock(StatefulObject.class);
+        Mockito.when(statefulObject.getState()).thenReturn("NEW");
         Mockito.doNothing().when(statefulObject).setState(any());
 
-        ArgumentCaptor<StateContext<State, Event>> contextCaptor = ArgumentCaptor.forClass(StateContext.class);
+        ArgumentCaptor<StateContext> contextCaptor = ArgumentCaptor.forClass(StateContext.class);
         Mockito.when(approveTransition.transit(contextCaptor.capture())).thenReturn(true);
 
-        lifecycleManager.execute(statefulObject, APPROVE);
-        StateContext<State, Event> context = contextCaptor.getValue();
+        lifecycleManager.execute(statefulObject, "APPROVE");
+        StateContext context = contextCaptor.getValue();
         context.putVariable("testKey", "testValue");
 
         assertEquals("testValue", context.getVariable("testKey", String.class));
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     void exceptionDueToAmbiguousTransition() {
-        Mockito.when(cancelTransition.getEvent()).thenReturn(APPROVE);
+        Mockito.when(cancelTransition.getEvent()).thenReturn("APPROVE");
 
-        StatefulObject<State> statefulObject = Mockito.mock(StatefulObject.class);
-        Mockito.when(statefulObject.getState()).thenReturn(NEW);
+        StatefulObject statefulObject = Mockito.mock(StatefulObject.class);
+        Mockito.when(statefulObject.getState()).thenReturn("NEW");
         Mockito.doNothing().when(statefulObject).setState(any());
 
-        assertThrows(AmbiguousTransitionException.class, () -> lifecycleManager.execute(statefulObject, APPROVE));
+        assertThrows(AmbiguousTransitionException.class, () -> lifecycleManager.execute(statefulObject, "APPROVE"));
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     void exceptionDueToNoSuchTransition() {
-        StatefulObject<State> statefulObject = Mockito.mock(StatefulObject.class);
-        Mockito.when(statefulObject.getState()).thenReturn(APPROVED);
+        StatefulObject statefulObject = Mockito.mock(StatefulObject.class);
+        Mockito.when(statefulObject.getState()).thenReturn("APPROVED");
         Mockito.doNothing().when(statefulObject).setState(any());
 
-        assertThrows(TransitionNotFoundException.class, () -> lifecycleManager.execute(statefulObject, APPROVE));
+        assertThrows(TransitionNotFoundException.class, () -> lifecycleManager.execute(statefulObject, "APPROVE"));
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     void transitionResultContainsExceptionIfItHappened() {
         Mockito.when(approveTransition.transit(any())).thenThrow(RuntimeException.class);
 
-        StatefulObject<State> statefulObject = Mockito.mock(StatefulObject.class);
-        Mockito.when(statefulObject.getState()).thenReturn(NEW);
+        StatefulObject statefulObject = Mockito.mock(StatefulObject.class);
+        Mockito.when(statefulObject.getState()).thenReturn("NEW");
         Mockito.doNothing().when(statefulObject).setState(any());
 
-        TransitionResult<State, Event> result = lifecycleManager.execute(statefulObject, APPROVE);
+        TransitionResult result = lifecycleManager.execute(statefulObject, "APPROVE");
 
         assertNotNull(result.getException());
         assertEquals(RuntimeException.class, result.getException().getClass());
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     void transitionResultIsNotSuccessfulIfTransitionReturnsFalse() {
         Mockito.when(approveTransition.transit(any())).thenReturn(false);
 
-        StatefulObject<State> statefulObject = Mockito.mock(StatefulObject.class);
-        Mockito.when(statefulObject.getState()).thenReturn(NEW);
+        StatefulObject statefulObject = Mockito.mock(StatefulObject.class);
+        Mockito.when(statefulObject.getState()).thenReturn("NEW");
         Mockito.doNothing().when(statefulObject).setState(any());
 
-        TransitionResult<State, Event> result = lifecycleManager.execute(statefulObject, APPROVE);
+        TransitionResult result = lifecycleManager.execute(statefulObject, "APPROVE");
 
         assertFalse(result.isSuccess());
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     void transitionResultIsNotSuccessfulIfTransitionThrowsException() {
         Mockito.when(approveTransition.transit(any())).thenThrow(RuntimeException.class);
 
-        StatefulObject<State> statefulObject = Mockito.mock(StatefulObject.class);
-        Mockito.when(statefulObject.getState()).thenReturn(NEW);
+        StatefulObject statefulObject = Mockito.mock(StatefulObject.class);
+        Mockito.when(statefulObject.getState()).thenReturn("NEW");
         Mockito.doNothing().when(statefulObject).setState(any());
 
-        TransitionResult<State, Event> result = lifecycleManager.execute(statefulObject, APPROVE);
+        TransitionResult result = lifecycleManager.execute(statefulObject, "APPROVE");
 
         assertFalse(result.isSuccess());
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     void stateMustBeChangedOnTargetIfTransitionIsSuccessful() {
-        ArgumentCaptor<State> stateCaptor = ArgumentCaptor.forClass(State.class);
-        StatefulObject<State> statefulObject = Mockito.mock(StatefulObject.class);
-        Mockito.when(statefulObject.getState()).thenReturn(NEW);
+        ArgumentCaptor<String> stateCaptor = ArgumentCaptor.forClass(String.class);
+        StatefulObject statefulObject = Mockito.mock(StatefulObject.class);
+        Mockito.when(statefulObject.getState()).thenReturn("NEW");
         Mockito.doNothing().when(statefulObject).setState(stateCaptor.capture());
 
-        lifecycleManager.execute(statefulObject, APPROVE);
+        lifecycleManager.execute(statefulObject, "APPROVE");
 
-        State actualTargetState = stateCaptor.getValue();
-        State expectedTargetState = approveTransition.getTargetState();
+        String actualTargetState = stateCaptor.getValue();
+        String expectedTargetState = approveTransition.getTargetState();
 
         assertEquals(expectedTargetState, actualTargetState);
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     void stateMustNotBeChangedIfTransitionReturnsFalse() {
         Mockito.when(approveTransition.transit(any())).thenReturn(false);
 
-        StatefulObject<State> statefulObject = Mockito.mock(StatefulObject.class);
-        Mockito.when(statefulObject.getState()).thenReturn(NEW);
+        StatefulObject statefulObject = Mockito.mock(StatefulObject.class);
+        Mockito.when(statefulObject.getState()).thenReturn("NEW");
         Mockito.doNothing().when(statefulObject).setState(any());
 
-        lifecycleManager.execute(statefulObject, APPROVE);
+        lifecycleManager.execute(statefulObject, "APPROVE");
 
         Mockito.verify(statefulObject, Mockito.times(0)).setState(approveTransition.getTargetState());
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     void stateMustNotBeChangedIfTransitionThrowsException() {
         Mockito.when(approveTransition.transit(any())).thenThrow(RuntimeException.class);
 
-        StatefulObject<State> statefulObject = Mockito.mock(StatefulObject.class);
-        Mockito.when(statefulObject.getState()).thenReturn(NEW);
+        StatefulObject statefulObject = Mockito.mock(StatefulObject.class);
+        Mockito.when(statefulObject.getState()).thenReturn("NEW");
         Mockito.doNothing().when(statefulObject).setState(any());
 
-        lifecycleManager.execute(statefulObject, APPROVE);
+        lifecycleManager.execute(statefulObject, "APPROVE");
 
         Mockito.verify(statefulObject, Mockito.times(0)).setState(approveTransition.getTargetState());
     }
 
-    @SuppressWarnings("unchecked")
     public static Stream<Arguments> getValidStatefulObjects() {
-        StatefulObject<State> o1 = Mockito.mock(StatefulObject.class);
-        StatefulObject<State> o2 = Mockito.mock(StatefulObject.class);
+        StatefulObject o1 = Mockito.mock(StatefulObject.class);
+        StatefulObject o2 = Mockito.mock(StatefulObject.class);
 
-        Mockito.when(o1.getState()).thenReturn(NEW);
+        Mockito.when(o1.getState()).thenReturn("NEW");
         Mockito.doNothing().when(o1).setState(any());
-        Mockito.when(o2.getState()).thenReturn(NEW);
+        Mockito.when(o2.getState()).thenReturn("NEW");
         Mockito.doNothing().when(o2).setState(any());
 
         return Stream.of(
-                Arguments.of(o1, APPROVE),
-                Arguments.of(o1, CANCEL)
+                Arguments.of(o1, "APPROVE"),
+                Arguments.of(o1, "CANCEL")
         );
     }
 }

--- a/state-machine/src/test/java/com/github/kabal163/statemachine/TransitionBuilderImplTest.java
+++ b/state-machine/src/test/java/com/github/kabal163/statemachine/TransitionBuilderImplTest.java
@@ -2,8 +2,6 @@ package com.github.kabal163.statemachine;
 
 import com.github.kabal163.statemachine.api.Action;
 import com.github.kabal163.statemachine.api.Condition;
-import com.github.kabal163.statemachine.testimpl.Event;
-import com.github.kabal163.statemachine.testimpl.State;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -14,20 +12,16 @@ import org.mockito.Mockito;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import static com.github.kabal163.statemachine.testimpl.Event.APPROVE;
-import static com.github.kabal163.statemachine.testimpl.State.APPROVED;
-import static com.github.kabal163.statemachine.testimpl.State.NEW;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class TransitionBuilderImplTest {
 
-    TransitionBuilderImpl<State, Event> transitionBuilder;
+    TransitionBuilderImpl transitionBuilder;
 
-    Action<State, Event> action;
-    Condition<State, Event> condition;
+    Action action;
+    Condition condition;
 
-    @SuppressWarnings("unchecked")
     TransitionBuilderImplTest() {
         action = Mockito.mock(Action.class);
         condition = Mockito.mock(Condition.class);
@@ -35,12 +29,12 @@ class TransitionBuilderImplTest {
 
     @BeforeEach
     void setUp() {
-        transitionBuilder = new TransitionBuilderImpl<>();
+        transitionBuilder = new TransitionBuilderImpl();
     }
 
     @ParameterizedTest
     @MethodSource("getTransitionBuildersWithIncompleteTransitions")
-    void exceptionDueToIncompleteTransition(TransitionBuilderImpl<State, Event> transitionBuilder) {
+    void exceptionDueToIncompleteTransition(TransitionBuilderImpl transitionBuilder) {
         assertThrows(IllegalStateException.class, transitionBuilder::buildTransitions);
     }
 
@@ -48,24 +42,24 @@ class TransitionBuilderImplTest {
     void successfulTransitionsBuild() {
         transitionBuilder
                 .with()
-                .sourceState(NEW)
-                .targetState(APPROVED)
-                .event(APPROVE)
+                .sourceState("NEW")
+                .targetState("APPROVED")
+                .event("APPROVE")
                 .condition(condition)
                 .action(action);
-        Set<Transition<State, Event>> transitions = transitionBuilder.buildTransitions();
+        Set<Transition> transitions = transitionBuilder.buildTransitions();
 
         assertEquals(1, transitions.size());
 
-        Transition<State, Event> transition = transitions.stream().findFirst().orElseThrow();
-        assertEquals(NEW, transition.getSourceState());
-        assertEquals(APPROVED, transition.getTargetState());
-        assertEquals(APPROVE, transition.getEvent());
+        Transition transition = transitions.stream().findFirst().orElseThrow();
+        assertEquals("NEW", transition.getSourceState());
+        assertEquals("APPROVED", transition.getTargetState());
+        assertEquals("APPROVE", transition.getEvent());
         assertEquals(1, transition.getConditions().size());
         assertEquals(1, transition.getActions().size());
 
-        Condition<State, Event> actualCondition = transition.getConditions().stream().findFirst().orElseThrow();
-        Action<State, Event> actualAction = transition.getActions().stream().findFirst().orElseThrow();
+        Condition actualCondition = transition.getConditions().stream().findFirst().orElseThrow();
+        Action actualAction = transition.getActions().stream().findFirst().orElseThrow();
 
         assertEquals(condition, actualCondition);
         assertEquals(action, actualAction);
@@ -73,7 +67,7 @@ class TransitionBuilderImplTest {
 
     @Test
     void exceptionDueToSkippingWithMethodInStartOfConfiguration() {
-        assertThrows(IllegalStateException.class, () -> transitionBuilder.sourceState(NEW));
+        assertThrows(IllegalStateException.class, () -> transitionBuilder.sourceState("NEW"));
     }
 
     @Test
@@ -88,10 +82,10 @@ class TransitionBuilderImplTest {
 
     public static Stream<Arguments> getTransitionBuildersWithIncompleteTransitions() {
         return Stream.of(
-                Arguments.of(new TransitionBuilderImpl<>().with()),
-                Arguments.of(new TransitionBuilderImpl<>().with().sourceState(NEW).targetState(APPROVED)),
-                Arguments.of(new TransitionBuilderImpl<>().with().sourceState(NEW).event(APPROVE)),
-                Arguments.of(new TransitionBuilderImpl<>().with().targetState(APPROVED).event(APPROVE))
+                Arguments.of(new TransitionBuilderImpl().with()),
+                Arguments.of(new TransitionBuilderImpl().with().sourceState("NEW").targetState("APPROVED")),
+                Arguments.of(new TransitionBuilderImpl().with().sourceState("NEW").event("APPROVE")),
+                Arguments.of(new TransitionBuilderImpl().with().targetState("APPROVED").event("APPROVE"))
         );
     }
 

--- a/state-machine/src/test/java/com/github/kabal163/statemachine/TransitionTest.java
+++ b/state-machine/src/test/java/com/github/kabal163/statemachine/TransitionTest.java
@@ -3,8 +3,6 @@ package com.github.kabal163.statemachine;
 import com.github.kabal163.statemachine.api.Action;
 import com.github.kabal163.statemachine.api.Condition;
 import com.github.kabal163.statemachine.api.StateContext;
-import com.github.kabal163.statemachine.testimpl.Event;
-import com.github.kabal163.statemachine.testimpl.State;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -21,18 +19,17 @@ import static org.mockito.ArgumentMatchers.any;
 
 class TransitionTest {
 
-    StateContext<State, Event> context;
+    StateContext context;
 
-    Action<State, Event> firstAction;
-    Action<State, Event> secondAction;
-    Action<State, Event> failedAction;
+    Action firstAction;
+    Action secondAction;
+    Action failedAction;
 
-    Condition<State, Event> successCondition;
-    Condition<State, Event> failedCondition;
+    Condition successCondition;
+    Condition failedCondition;
 
-    Transition<State, Event> transition;
+    Transition transition;
 
-    @SuppressWarnings("unchecked")
     TransitionTest() {
         context = Mockito.mock(StateContext.class);
         firstAction = Mockito.mock(Action.class);
@@ -51,7 +48,7 @@ class TransitionTest {
 
     @BeforeEach
     void setUp() {
-        transition = new Transition<>();
+        transition = new Transition();
     }
 
     @Test
@@ -108,18 +105,17 @@ class TransitionTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     void actionsOrderMustBeTheSameAsOnConfiguration() {
-        Action<State, Event> thirdAction = Mockito.mock(Action.class);
-        Action<State, Event> fourthAction = Mockito.mock(Action.class);
+        Action thirdAction = Mockito.mock(Action.class);
+        Action fourthAction = Mockito.mock(Action.class);
 
         transition.addAction(firstAction);
         transition.addAction(secondAction);
         transition.addAction(thirdAction);
         transition.addAction(fourthAction);
 
-        List<Action<State, Event>> expectedActions = List.of(firstAction, secondAction, thirdAction, fourthAction);
-        List<Action<State, Event>> actualActions = new ArrayList<>(transition.getActions());
+        List<Action> expectedActions = List.of(firstAction, secondAction, thirdAction, fourthAction);
+        List<Action> actualActions = new ArrayList<>(transition.getActions());
 
         boolean result = IntStream.range(0, 4)
                 .allMatch(i -> Objects.equals(expectedActions.get(i), actualActions.get(i)));

--- a/state-machine/src/test/java/com/github/kabal163/statemachine/testimpl/Event.java
+++ b/state-machine/src/test/java/com/github/kabal163/statemachine/testimpl/Event.java
@@ -1,8 +1,0 @@
-package com.github.kabal163.statemachine.testimpl;
-
-public enum Event {
-
-    CREATE,
-    APPROVE,
-    CANCEL
-}

--- a/state-machine/src/test/java/com/github/kabal163/statemachine/testimpl/State.java
+++ b/state-machine/src/test/java/com/github/kabal163/statemachine/testimpl/State.java
@@ -1,8 +1,0 @@
-package com.github.kabal163.statemachine.testimpl;
-
-public enum State {
-
-    NEW,
-    APPROVED,
-    CANCELED
-}


### PR DESCRIPTION
Now the state machine uses Strings type for states and event.
It allows us to get rid of generic types in API.